### PR TITLE
feat: indoor manager support

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
   },
   "peerDependencies": {
     "azure-maps-control": "2.0.32",
+    "azure-maps-indoor": "^0.1.2",
     "guid-typescript": "^1.0.9",
     "mapbox-gl": "^1.10.0",
     "react": "^16.10.2",
@@ -122,6 +123,7 @@
   },
   "dependencies": {
     "azure-maps-control": "2.0.32",
+    "azure-maps-indoor": "^0.1.2",
     "guid-typescript": "^1.0.9",
     "mapbox-gl": "^1.10.0"
   }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -35,7 +35,7 @@ export default {
     include: "src/**",
   },
   plugins: [
-    externals({ peerDeps: true, deps: true, exclude: "azure-maps-control" }),
+    externals({ peerDeps: true, deps: true, exclude: ["azure-maps-control", "azure-maps-indoor"] }),
     replace({
       "process.env.NODE_ENV": JSON.stringify(env),
       preventAssignment: true,

--- a/src/contexts/AzureMapIndoorManagerContext.tsx
+++ b/src/contexts/AzureMapIndoorManagerContext.tsx
@@ -1,0 +1,109 @@
+import React, { createContext, useContext, useEffect, useState } from 'react'
+import { indoor, control } from 'azure-maps-indoor'
+import { IAzureMapIndoorManagerEventType, IAzureMapIndoorManagerStatefulProviderProps, IAzureMapsContextProps, MapType } from '../types'
+import { AzureMapsContext } from './AzureMapContext'
+import { useCheckRef } from '../hooks/useCheckRef'
+
+const AzureMapIndoorManagerContext = createContext<{}>({ 
+  indoorManagerRef: null 
+})
+
+const { Provider: IndoorManagerProvider, Consumer: AzureMapIndoorManagerConsumer } = AzureMapIndoorManagerContext
+
+const AzureMapIndoorManagerStatefulProvider = ({
+  options,
+  children,
+  dynamicStyling = false,
+  facility = { facilityId: '', levelOrdinal: 0 },
+  events = {}
+}: IAzureMapIndoorManagerStatefulProviderProps) => {
+  const { mapRef } = useContext<IAzureMapsContextProps>(AzureMapsContext)
+  const [ indoorManagerRef, setIndoorManagerRef ] = useState<indoor.IndoorManager | null>(null)
+  const [ levelControlRef, setLevelControlRef ] = useState<control.LevelControl | undefined>(undefined)
+
+  useCheckRef<MapType, MapType>(mapRef, mapRef, mref => {
+    mref.events.add('ready', () => {
+      const indoorManager = new indoor.IndoorManager(mref)
+      const levelControl = options.levelControl ? new control.LevelControl(options.levelControl) : undefined
+      indoorManager.setOptions({
+        ...options,
+        levelControl
+      })
+      
+      indoorManager.setDynamicStyling(dynamicStyling)
+      indoorManager.setFacility(facility.facilityId, facility.levelOrdinal)
+
+      setIndoorManagerRef(indoorManager)
+      setLevelControlRef(levelControl)
+
+      // TODO: gracefully handle the change of props events object
+      for(const eventType in events){
+        const handler = events[eventType as IAzureMapIndoorManagerEventType]
+        if(!handler){ 
+          continue 
+        }
+
+        mref.events.add(eventType as any, indoorManager, handler)
+      }
+
+      return () => {
+        indoorManager.dispose()
+        setIndoorManagerRef(null)
+        setLevelControlRef(undefined)
+
+        for(const eventType in events){
+          const handler = events[eventType as IAzureMapIndoorManagerEventType]
+          if(!handler){ 
+            continue 
+          }
+
+          mref.events.remove(eventType, indoorManager, handler)
+        }
+      }
+    })
+  })
+
+  useCheckRef(indoorManagerRef, options, (imref, options) => {
+    imref.setOptions({
+      ...options,
+      levelControl: options.levelControl ? levelControlRef : undefined
+    })
+  })
+
+  useCheckRef(levelControlRef, options.levelControl, () => {
+    if(!options.levelControl){
+      setLevelControlRef(undefined)
+    } else {
+      // NOTE: LevelControl does not yet support dynamically updating options yet 
+      // levelControlRef.setOptions(options.levelControl)
+      if(indoorManagerRef){
+        const levelControl = new control.LevelControl(options.levelControl)
+        setLevelControlRef(levelControl)
+        indoorManagerRef.setOptions({
+          ...options,
+          levelControl
+        })
+      }
+    }
+  })
+
+  useCheckRef(indoorManagerRef, dynamicStyling, (imref) => {
+    imref.setDynamicStyling(dynamicStyling)
+  })
+
+  useCheckRef(indoorManagerRef, facility, (imref) => {
+    imref.setFacility(facility.facilityId, facility.levelOrdinal)
+  })
+
+  return (
+    <IndoorManagerProvider value={{indoorManagerRef}}>
+      {mapRef && indoorManagerRef && children}
+    </IndoorManagerProvider>
+  )
+}
+
+export {
+  AzureMapIndoorManagerContext,
+  AzureMapIndoorManagerConsumer,
+  AzureMapIndoorManagerStatefulProvider as AzureMapIndoorManagerProvider
+}

--- a/src/react-azure-maps.ts
+++ b/src/react-azure-maps.ts
@@ -17,6 +17,11 @@ export {
   AzureMapLayerConsumer,
   AzureMapLayerProvider
 } from './contexts/AzureMapLayerContext'
+export {
+  AzureMapIndoorManagerContext,
+  AzureMapIndoorManagerConsumer,
+  AzureMapIndoorManagerProvider
+} from './contexts/AzureMapIndoorManagerContext'
 export { default as AzureMapPopup } from './components/AzureMapPopup/AzureMapPopup'
 export { default as useCreatePopup } from './components/AzureMapPopup/useCreateAzureMapPopup'
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,8 @@ import atlas, {
   LayerOptions
 } from 'azure-maps-control'
 
+import { indoor, control } from 'azure-maps-indoor'
+
 export type IAzureMapOptions = ServiceOptions &
   StyleOptions &
   UserInteractionOptions &
@@ -44,6 +46,7 @@ export type IAzureMapChildren =
   | ReactElement<IAzureMapHtmlMarker>
   | ReactElement<IAzureMapPopup>
   | ReactElement<IAzureMapDataSourceProps>
+  | ReactElement<IAzureMapIndoorManagerStatefulProviderProps>
 
 export type IAzureMap = {
   children?: Array<IAzureMapChildren> | IAzureMapChildren
@@ -196,6 +199,21 @@ export type IAzureLayerStatefulProviderProps = {
   events?: IAzureMapLayerEvent | any
   onCreateCustomLayer?: (dataSourceRef: DataSourceType, mapRef: MapType | null) => atlas.layer.Layer
   lifecycleEvents?: IAzureMapLifecycleEvent | any
+}
+
+export type IAzureMapIndoorManagerEvent = {
+  facilitychanged?: (e: indoor.IFacilityChangeEvent) => void,
+  levelchanged?: (e: indoor.ILevelChangeEvent) => void
+}
+
+export type IAzureMapIndoorManagerEventType = keyof IAzureMapIndoorManagerEvent
+
+export type IAzureMapIndoorManagerStatefulProviderProps = {
+  options: Omit<indoor.IndoorManagerOptions, 'levelControl'> & { 'levelControl'?: control.LevelControlOptions },
+  children?: ReactElement,
+  dynamicStyling?: boolean,
+  facility?: { facilityId: string, levelOrdinal: number },
+  events?: IAzureMapIndoorManagerEvent 
 }
 
 export type IAzureMapLayerLifecycleEvents = 'layeradded' | 'layerremoved'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2155,6 +2155,150 @@
   dependencies:
     "@babel/runtime" "^7.12.5"
 
+"@turf/bbox-polygon@^6.0.1":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@turf/bbox-polygon/-/bbox-polygon-6.3.0.tgz#9ffa79d56ae50cc7730b35b2a6d2a02493268365"
+  integrity sha512-CCyTBM8LzGRu/lReNlgDyjRO8NojtJ7EPPvSl3bdKQbNFsCm25gwe7Y3xsaCkWLNn5g89lQJI9Izf9xdEsENjQ==
+  dependencies:
+    "@turf/helpers" "^6.3.0"
+
+"@turf/bbox@*", "@turf/bbox@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@turf/bbox/-/bbox-6.3.0.tgz#0e1a9b59f32d6a2a40c806f54cbaa73575bead25"
+  integrity sha512-N4ue5Xopu1qieSHP2MA/CJGWHPKaTrVXQJjzHRNcY1vtsO126xbSaJhWUrFc5x5vVkXp0dcucGryO0r5m4o/KA==
+  dependencies:
+    "@turf/helpers" "^6.3.0"
+    "@turf/meta" "^6.3.0"
+
+"@turf/bearing@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@turf/bearing/-/bearing-6.3.0.tgz#4de3f398382772031e84491734902b8d37bc8c84"
+  integrity sha512-apuUm9xN6VQLO33m7F2mmzlm3dHfeesJjMSzh9iehGtgmp1IaVndjdcIvs0ieiwm8bN9UhwXpfPtO3pV0n9SFw==
+  dependencies:
+    "@turf/helpers" "^6.3.0"
+    "@turf/invariant" "^6.3.0"
+
+"@turf/boolean-contains@^6.0.1":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@turf/boolean-contains/-/boolean-contains-6.3.0.tgz#fe4fc359e408c8c3c89e7fb159c9d31fde48779a"
+  integrity sha512-1MW7B5G5tIu1lnAv3pXyFzl75wfBYnbA2GhwHDb4okIXMhloy/r5uIqAZHo0fOXykKVJS/gIfA/MioKIftoTug==
+  dependencies:
+    "@turf/bbox" "^6.3.0"
+    "@turf/boolean-point-in-polygon" "^6.3.0"
+    "@turf/boolean-point-on-line" "^6.3.0"
+    "@turf/helpers" "^6.3.0"
+    "@turf/invariant" "^6.3.0"
+
+"@turf/boolean-overlap@^6.0.1":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@turf/boolean-overlap/-/boolean-overlap-6.3.0.tgz#b696945154fc85f8e700b82f8e15502a03995b35"
+  integrity sha512-rWh8JKTqlJ1m27FY8YeWcGoXutLyCVfSi2/8AOkXi2F+36P9GM4tHz19yKY3btbnHJTgSZf1xO2YhX2d0BmNqg==
+  dependencies:
+    "@turf/helpers" "^6.3.0"
+    "@turf/invariant" "^6.3.0"
+    "@turf/line-intersect" "^6.3.0"
+    "@turf/line-overlap" "^6.3.0"
+    "@turf/meta" "^6.3.0"
+    geojson-equality "0.1.6"
+
+"@turf/boolean-point-in-polygon@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-6.3.0.tgz#784952a36c64119e90fbe94650245da62ecd8fc2"
+  integrity sha512-NqFSsoE6OwhDK19IllDQRhEQEkF7UVEOlqH9vgS1fGg4T6NcyKvACJs05c9457tL7QSbV9ZS53f2qiLneFL+qg==
+  dependencies:
+    "@turf/helpers" "^6.3.0"
+    "@turf/invariant" "^6.3.0"
+
+"@turf/boolean-point-on-line@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@turf/boolean-point-on-line/-/boolean-point-on-line-6.3.0.tgz#1fe7b5c0979695260011b93036f0e7042cb5195b"
+  integrity sha512-eScH8sfKJVjfbEX5Hgkt1nA7A8DUoiYD1riUVqTp2xikujrMfnYRjFpL/UAo01v33cPKZlhCXp7NE86bdOSrYg==
+  dependencies:
+    "@turf/helpers" "^6.3.0"
+    "@turf/invariant" "^6.3.0"
+
+"@turf/destination@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@turf/destination/-/destination-6.3.0.tgz#7032eeb0ec5d1a035d98faaddac039eea96abb04"
+  integrity sha512-aLt3U/XkJWyZW08Ln1qZwBNAGh27yhmYLu892+dBj3gKP6UUiR6ZopXxrBwjBVe00A6k2ktftKDn79qe0hptuw==
+  dependencies:
+    "@turf/helpers" "^6.3.0"
+    "@turf/invariant" "^6.3.0"
+
+"@turf/distance@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@turf/distance/-/distance-6.3.0.tgz#4bd084af7fe369e921476e52b597a638dae4ed95"
+  integrity sha512-basi24ssNFnH3iXPFjp/aNUrukjObiFWoIyDRqKyBJxVwVOwAWvfk4d38QQyBj5nDo5IahYRq/Q+T47/5hSs9w==
+  dependencies:
+    "@turf/helpers" "^6.3.0"
+    "@turf/invariant" "^6.3.0"
+
+"@turf/helpers@6.x", "@turf/helpers@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-6.3.0.tgz#87f90f806c3f8ad6385ef8d2041d3662bf3c9fb1"
+  integrity sha512-kr6KuD4Z0GZ30tblTEvi90rvvVNlKieXuMC8CTzE/rVQb0/f/Cb29zCXxTD7giQTEQY/P2nRW23wEqqyNHulCg==
+
+"@turf/invariant@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-6.3.0.tgz#04a22b26c5503146c03fa6198176b72bd591eadf"
+  integrity sha512-2OFOi9p+QOrcIMySEnr+WlOiKaFZ1bY56jA98YyECewJHfhPFWUBZEhc4nWGRT0ahK08Vus9+gcuBX8QIpCIIw==
+  dependencies:
+    "@turf/helpers" "^6.3.0"
+
+"@turf/line-intersect@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@turf/line-intersect/-/line-intersect-6.3.0.tgz#726a50edc66bb7b5e798b052b103fb0da4d1c4f4"
+  integrity sha512-3naxR7XpkPd2vst3Mw6DFry4C9m3o0/f2n/xu5UAyxb88Ie4m2k+1eqkhzMMx/0L+E6iThWpLx7DASM6q6o9ow==
+  dependencies:
+    "@turf/helpers" "^6.3.0"
+    "@turf/invariant" "^6.3.0"
+    "@turf/line-segment" "^6.3.0"
+    "@turf/meta" "^6.3.0"
+    geojson-rbush "3.x"
+
+"@turf/line-overlap@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@turf/line-overlap/-/line-overlap-6.3.0.tgz#c7e92c09e7626e1287a80742df7f509f0b4da693"
+  integrity sha512-fVyXfTpr/A+ZXZWG6PbuYz5rAGbTQWyrMZveCl2049SbOXSkVXGjUfpnLaklP0p+adw7eRR0LhZn6FGz9CQaFg==
+  dependencies:
+    "@turf/boolean-point-on-line" "^6.3.0"
+    "@turf/helpers" "^6.3.0"
+    "@turf/invariant" "^6.3.0"
+    "@turf/line-segment" "^6.3.0"
+    "@turf/meta" "^6.3.0"
+    "@turf/nearest-point-on-line" "^6.3.0"
+    deep-equal "1.x"
+    geojson-rbush "3.x"
+
+"@turf/line-segment@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@turf/line-segment/-/line-segment-6.3.0.tgz#b37d6877ee4425ebc12698860e7d355d1bf2ba9b"
+  integrity sha512-M+aDy83V+E7jYWNaf+b+A88yhnMrJhyg/lhAj6mU6UeB2PbruXB2qgSmmVDSE2dIknOvZZuIWNzEzUI07RO2kw==
+  dependencies:
+    "@turf/helpers" "^6.3.0"
+    "@turf/invariant" "^6.3.0"
+    "@turf/meta" "^6.3.0"
+
+"@turf/meta@6.x", "@turf/meta@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@turf/meta/-/meta-6.3.0.tgz#f3e280ab29641f21e4f99310ce77f9c8394ae394"
+  integrity sha512-qBJjaAJS9H3ap0HlGXyF/Bzfl0qkA9suafX/jnDsZvWMfVLt+s+o6twKrXOGk5t7nnNON2NFRC8+czxpu104EQ==
+  dependencies:
+    "@turf/helpers" "^6.3.0"
+
+"@turf/nearest-point-on-line@^6.3.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@turf/nearest-point-on-line/-/nearest-point-on-line-6.3.0.tgz#a33f14fb099c292777de136f8c96ef4a7cad8ae2"
+  integrity sha512-b4C9Md1VbGn9chMgdSj2grJD4w4t0owEWOKEBwOZfdhrcksyOedVvKB7XqOFdj/8Jitel40EKAC5LQTNu24kEQ==
+  dependencies:
+    "@turf/bearing" "^6.3.0"
+    "@turf/destination" "^6.3.0"
+    "@turf/distance" "^6.3.0"
+    "@turf/helpers" "^6.3.0"
+    "@turf/invariant" "^6.3.0"
+    "@turf/line-intersect" "^6.3.0"
+    "@turf/meta" "^6.3.0"
+
 "@types/adal-angular@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/adal-angular/-/adal-angular-1.0.1.tgz#424822e2e17a6c185f33ef80b1208f035e52a735"
@@ -2228,6 +2372,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/geojson@*":
+  version "7946.0.7"
+  resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.7.tgz#c8fa532b60a0042219cdf173ca21a975ef0666ad"
+  integrity sha512-wE2v81i4C4Ol09RtsWFAqg3BUitWbHSpSlIo+bNdsCJijO9sjme+zm+73ZMCa/qMC8UEERxzGbvmr1cffo2SiQ==
+
 "@types/glob@^7.1.1":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.3.tgz#e6ba80f36b7daad2c685acd9266382e68985c183"
@@ -2284,6 +2433,13 @@
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+
+"@types/mapbox-gl@^1.11.2":
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/@types/mapbox-gl/-/mapbox-gl-1.13.0.tgz#914836d0ea5d1a433252c8debeef75d410c3d062"
+  integrity sha512-z5YxncrARfKaJXzkhy4qS0cOldMfGIXq5yOPQcU9S12/xjAe3m66scftYlV1E10Em5QGdW2xahBb3CPk/dDcqA==
+  dependencies:
+    "@types/geojson" "*"
 
 "@types/minimatch@*":
   version "3.0.4"
@@ -3156,12 +3312,24 @@ axobject-query@^2.2.0:
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
   integrity sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==
 
-azure-maps-control@2.0.32:
+azure-maps-control@2.0.32, azure-maps-control@^2.0.28:
   version "2.0.32"
   resolved "https://registry.yarnpkg.com/azure-maps-control/-/azure-maps-control-2.0.32.tgz#9844449275f964af4acd530cbcd6f3842758a23e"
   integrity sha512-MgesL97292XIFNWVo/7koVpxGYW9g5AJx5XlJCXpg0teYUPrz+YsMUnyvNOQviHO3stvsBtQpEGT5gdwVibVIA==
   dependencies:
     "@types/adal-angular" "^1.0.1"
+
+azure-maps-indoor@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/azure-maps-indoor/-/azure-maps-indoor-0.1.2.tgz#728088b622b74b9ef4f179748ec2ee1462023d52"
+  integrity sha512-B632Z7e/yy+gcsULoCh2Hb59Dl8rj7Qh2P0aG/3u0bGwI6f8Aq4yt7QgXNLm2HKKtf89ESSyfay/n8BzeOaKjg==
+  dependencies:
+    "@turf/bbox-polygon" "^6.0.1"
+    "@turf/boolean-contains" "^6.0.1"
+    "@turf/boolean-overlap" "^6.0.1"
+    "@types/mapbox-gl" "^1.11.2"
+    azure-maps-control "^2.0.28"
+    nouislider "^14.6.1"
 
 babel-code-frame@^6.26.0:
   version "6.26.0"
@@ -5305,7 +5473,7 @@ dedent@^0.7.0:
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
 
-deep-equal@^1.0.1:
+deep-equal@1.x, deep-equal@^1.0.0, deep-equal@^1.0.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.1.tgz#b5c98c942ceffaf7cb051e24e1434a25a2e6076a"
   integrity sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==
@@ -6687,6 +6855,23 @@ gensync@^1.0.0-beta.1, gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
+
+geojson-equality@0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/geojson-equality/-/geojson-equality-0.1.6.tgz#a171374ef043e5d4797995840bae4648e0752d72"
+  integrity sha1-oXE3TvBD5dR5eZWEC65GSOB1LXI=
+  dependencies:
+    deep-equal "^1.0.0"
+
+geojson-rbush@3.x:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/geojson-rbush/-/geojson-rbush-3.1.2.tgz#577d6ec70ba986d4e60b741f1df5147faeb82c97"
+  integrity sha512-grkfdg3HIeTjwTfiJe5FT8+fGU3fABCc+vRJDBwdQz9kkLF0Sbif2gs2JUzjewwgmnvLGy9fInySDeADoNuk7w==
+  dependencies:
+    "@turf/bbox" "*"
+    "@turf/helpers" "6.x"
+    "@turf/meta" "6.x"
+    rbush "^2.0.0"
 
 geojson-vt@^3.2.1:
   version "3.2.1"
@@ -9528,6 +9713,11 @@ normalize-url@^3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
   integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
 
+nouislider@^14.6.1:
+  version "14.7.0"
+  resolved "https://registry.yarnpkg.com/nouislider/-/nouislider-14.7.0.tgz#a71db0587c92567b6da1df57d251d3696d942362"
+  integrity sha512-4RtQ1+LHJKesDCNJrXkQcwXAWCrC2aggdLYMstS/G5fEWL+fXZbUA9pwVNHFghMGuFGRATlDLNInRaPeRKzpFQ==
+
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -11289,6 +11479,11 @@ quick-lru@^4.0.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
   integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
 
+quickselect@^1.0.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/quickselect/-/quickselect-1.1.1.tgz#852e412ce418f237ad5b660d70cffac647ae94c2"
+  integrity sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ==
+
 quickselect@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/quickselect/-/quickselect-2.0.0.tgz#f19680a486a5eefb581303e023e98faaf25dd018"
@@ -11339,6 +11534,13 @@ raw-body@2.4.0:
     http-errors "1.7.2"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
+
+rbush@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/rbush/-/rbush-2.0.2.tgz#bb6005c2731b7ba1d5a9a035772927d16a614605"
+  integrity sha512-XBOuALcTm+O/H8G90b6pzu6nX6v2zCKiFG4BJho8a+bY6AER6t8uQUZdi5bomQc0AprCWhEGa7ncAbbRap0bRA==
+  dependencies:
+    quickselect "^1.0.1"
 
 react-app-polyfill@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Adds support for Azure Map Creator Indoor Manager plugin.

Sample usage:

```jsx
const tilesetId = "YOUR_TILESET_ID"

const options = {
  authOptions: {
    authType: "subscriptionKey",
    subscriptionKey: "YOUR_PRIMARY_SUB_KEY",
  },

  center: [-122.13203, 47.63645],
  zoom: 19,
  style: 'Grayscale_light',
  view: 'Auto'
};

const DefaultMap = () => (
  <AzureMapsProvider>
    <div style={{ height: '100vh', margin: 0 }}>
      <AzureMap options={options}>
        <AzureMapIndoorManagerProvider 
          options={{ 
            tilesetId, 
            theme: 'dark',
            levelControl: { position: 'top-right' }}}
          events={{
            facilitychanged: eventData => console.log(eventData),
            levelchanged: eventData => console.log(eventData)
          }}
        />
      </AzureMap>
    </div>
  </AzureMapsProvider>
);

export default DefaultMap;
```

Unit tests and example in examples repo are pending.

**Additional notes:**
Since the conversion of cad file (.dwg) to tileset consists of multiple REST api calls (described at [tutorial-creator-indoor-maps](https://docs.microsoft.com/en-us/azure/azure-maps/tutorial-creator-indoor-maps)), I have added a shell script to simplify this for the simple usecase: [upload_indoor.sh](https://gist.github.com/ambientlight/3c75754d86a0217d90e9ceca939aff9d) , example .dwg .zip bundle can be found at [Azure-Samples/am-creator-indoor-data-samples](https://github.com/Azure-Samples/am-creator-indoor-data-examples)