### PR TITLE
Fix: missing popups.add to make sure popup container get attached

### DIFF
--- a/src/components/AzureMapPopup/useCreateAzureMapPopup.ts
+++ b/src/components/AzureMapPopup/useCreateAzureMapPopup.ts
@@ -2,8 +2,9 @@ import { useState, useEffect, useContext } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import atlas from 'azure-maps-control'
 
-import { IAzureMapPopup, IAzureMapsContextProps } from '../../types'
+import { IAzureMapPopup, IAzureMapsContextProps, MapType } from '../../types'
 import { AzureMapsContext } from '../../contexts/AzureMapContext'
+import { useCheckRef } from '../../hooks/useCheckRef'
 export const useCreatePopup = ({
   options,
   popupContent,
@@ -13,6 +14,10 @@ export const useCreatePopup = ({
     new atlas.Popup({ ...options, content: renderToStaticMarkup(popupContent) })
   )
   const { mapRef } = useContext<IAzureMapsContextProps>(AzureMapsContext)
+
+  useCheckRef<MapType, MapType>(mapRef, mapRef, mref => {
+    mref.events.addOnce('ready', () => mref.popups.add(popupRef))
+  })
 
   useEffect(() => {
     popupRef.setOptions({


### PR DESCRIPTION
Accessibility usecase (keyboard navigation of popups) discussed in #87 uncovered the issue where `atlas.Popup` is actually never added explicitly to `PopupManager` that results in popup containers not getting added to the DOM (unless `isVisible`) which breaks the keyboard-based navigation needed in #87