### PR TITLE
Updated to ES6 to try to resolve compatibility issues with Azure Maps…

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "react-azure-maps"
   ],
   "source": "src/react-azure-maps.ts",
-  "module": "dist/react-azure-maps.es5.js",
+  "module": "dist/react-azure-maps.es6.js",
   "typings": "dist/types/react-azure-maps.d.ts",
   "files": [
     "dist"

--- a/preview/react-preview.jsx
+++ b/preview/react-preview.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom";
-import { AzureMap, AzureMapsProvider } from '../dist/react-azure-maps.es5';
+import { AzureMap, AzureMapsProvider } from '../dist/react-azure-maps.es6';
 
 const option = {
   authOptions: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "moduleResolution": "node",
-    "target": "es5",
+    "target": "es6",
     "module": "es2015",
     "lib": ["es2015", "es2016", "es2017", "dom"],
     "strict": true,


### PR DESCRIPTION
Updated to es6 instead of es5 in order to try to resolve the incompatiblity issue with Azure Maps Html Layer.

See issue: https://github.com/WiredSolutions/react-azure-maps/issues/97