### PR TITLE
chore(deps): upgrade to react 18

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+    "trailingComma": "none",
+    "semi": false,
+    "singleQuote": true
+}

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,1 @@
-module.exports = { extends: ['@commitlint/config-angular'] }
+module.exports = { extends: ['@commitlint/config-conventional'] }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-azure-maps",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "React Wrapper for Azure Maps",
   "keywords": [
     "react",
@@ -84,12 +84,11 @@
     "@rollup/plugin-node-resolve": "^10.0.0",
     "@rollup/plugin-replace": "^2.3.4",
     "@testing-library/jest-dom": "^5.11.4",
-    "@testing-library/react": "^11.1.0",
-    "@testing-library/react-hooks": "^5.1.0",
+    "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^12.1.10",
     "@types/jest": "^26.0.15",
-    "@types/react": "^17.0.39",
-    "@types/react-dom": "^17.0.11",
+    "@types/react": "^18.0.15",
+    "@types/react-dom": "^18.0.6",
     "babel-preset-env": "^1.7.0",
     "concurrently": "^5.3.0",
     "cross-env": "^7.0.2",
@@ -98,8 +97,8 @@
     "lint-staged": "^10.5.2",
     "parcel-bundler": "1.12.3",
     "prettier": "^2.2.0",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "react-scripts": "4.0.1",
     "rollup": "^2.33.3",
     "rollup-plugin-copy": "^3.4.0",
@@ -117,8 +116,8 @@
     "azure-maps-control": "2.0.32",
     "guid-typescript": "^1.0.9",
     "mapbox-gl": "^1.10.0",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^17.0.2 || ^18.0.0",
+    "react-dom": "^17.0.2 || ^18.0.0"
   },
   "dependencies": {
     "azure-maps-control": "2.0.32",

--- a/preview/react-preview.jsx
+++ b/preview/react-preview.jsx
@@ -1,22 +1,22 @@
-import React from "react";
-import ReactDOM from "react-dom";
-import { AzureMap, AzureMapsProvider } from '../dist/react-azure-maps.es5';
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import { AzureMap, AzureMapsProvider } from '../dist/react-azure-maps.es5'
 
 const option = {
   authOptions: {
-    authType: "subscriptionKey",
-    subscriptionKey: "",
-  },
-};
+    authType: 'subscriptionKey',
+    subscriptionKey: ''
+  }
+}
 
-const DefaultMap= () => (
+const DefaultMap = () => (
   <AzureMapsProvider>
     <div style={{ height: '300px' }}>
       <AzureMap options={option} />
     </div>
   </AzureMapsProvider>
-);
+)
 
-export default DefaultMap;
+export default DefaultMap
 
-ReactDOM.render(<DefaultMap />, document.getElementById("root"));
+createRoot(document.getElementById('root')).render(<DefaultMap />)

--- a/src/components/AzureMap/useCreateMapControl.test.tsx
+++ b/src/components/AzureMap/useCreateMapControl.test.tsx
@@ -1,9 +1,5 @@
-import { renderHook } from '@testing-library/react-hooks'
-import {
-  createControl,
-  createMapControls,
-  createMapCustomControls
-} from './useCreateMapControls'
+import { renderHook } from '@testing-library/react'
+import { createControl, createMapControls, createMapCustomControls } from './useCreateMapControls'
 import { Map } from 'azure-maps-control'
 import { IAzureMapControls, IAzureCustomControls } from '../../types'
 

--- a/src/components/AzureMap/useCreateSprites.test.tsx
+++ b/src/components/AzureMap/useCreateSprites.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks'
+import { renderHook } from '@testing-library/react'
 import { createImageSprites } from './useCreateSprites'
 import { Map } from 'azure-maps-control'
 
@@ -25,7 +25,7 @@ describe('createImageSprites tests', () => {
     )
   })
 
-  it('should create image sprintes with no icon field and not call imageSprite.add ', async () => {
+  it('should create image sprintes with no icon field and not call imageSprite.add', async () => {
     const mockMap = new Map('#fake-container', {})
     const fakeImageSprite = {
       id: 'id',

--- a/src/components/AzureMapFeature/useFeature.test.tsx
+++ b/src/components/AzureMapFeature/useFeature.test.tsx
@@ -1,7 +1,7 @@
 import atlas, { data, source } from 'azure-maps-control'
 import { useFeature } from './useFeature'
 import { IAzureMapFeature } from '../../types'
-import { renderHook } from '@testing-library/react-hooks'
+import { renderHook } from '@testing-library/react'
 
 const fakePosition = new data.Point(new data.Position(0, 0))
 

--- a/src/components/AzureMapPopup/useCreateAzureMapPopup.test.tsx
+++ b/src/components/AzureMapPopup/useCreateAzureMapPopup.test.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react'
-import { renderHook } from '@testing-library/react-hooks'
+import { renderHook } from '@testing-library/react'
 import { Map } from 'azure-maps-control'
 import React from 'react'
 import { AzureMapsContext } from '../../contexts/AzureMapContext'

--- a/src/contexts/AzureMapContext.test.tsx
+++ b/src/contexts/AzureMapContext.test.tsx
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react'
-import { renderHook } from '@testing-library/react-hooks'
+import { renderHook } from '@testing-library/react'
+import { act } from 'react-dom/test-utils'
 import { Map } from 'azure-maps-control'
 import { AzureMapsContext, AzureMapsProvider } from '../contexts/AzureMapContext'
 
@@ -20,8 +21,10 @@ describe('AzureMapDataSourceProvider tests', () => {
     const { result } = renderHook(() => useContextConsumer(), {
       wrapper: wrapDataWithAzureMapsContext
     })
-    result.current.setMapRef(mapRef)
-    result.current.setMapReady(true)
+    act(() => {
+      result.current.setMapRef(mapRef)
+      result.current.setMapReady(true)
+    })
     expect(result.current.mapRef).toEqual(mapRef)
   })
 

--- a/src/contexts/AzureMapDataSourceContext.test.tsx
+++ b/src/contexts/AzureMapDataSourceContext.test.tsx
@@ -1,5 +1,5 @@
 import { useContext } from 'react'
-import { renderHook } from '@testing-library/react-hooks'
+import { renderHook } from '@testing-library/react'
 import atlas, { Map } from 'azure-maps-control'
 import React from 'react'
 import { AzureMapsContext } from '../contexts/AzureMapContext'
@@ -66,7 +66,9 @@ describe('AzureMapDataSourceProvider tests', () => {
       wrapper: wrapWithDataSourceContext({ id: 'id', dataFromUrl: 'dataFromUrl' })
     })
     expect(result.current.dataSourceRef).toBeInstanceOf(atlas.source.DataSource)
-    expect((result.current.dataSourceRef as atlas.source.DataSource).importDataFromUrl).toHaveBeenCalledWith('dataFromUrl')
+    expect(
+      (result.current.dataSourceRef as atlas.source.DataSource).importDataFromUrl
+    ).toHaveBeenCalledWith('dataFromUrl')
   })
 
   it('should call add collection if collection was not falsy', () => {
@@ -95,6 +97,8 @@ describe('AzureMapDataSourceProvider tests', () => {
       wrapper: wrapWithDataSourceContext({ id: 'id', options: { option: 'option' } })
     })
     expect(result.current.dataSourceRef).toBeInstanceOf(atlas.source.DataSource)
-    expect((result.current.dataSourceRef as atlas.source.DataSource).setOptions).toHaveBeenLastCalledWith({ option: 'option' })
+    expect(
+      (result.current.dataSourceRef as atlas.source.DataSource).setOptions
+    ).toHaveBeenLastCalledWith({ option: 'option' })
   })
 })

--- a/src/contexts/AzureMapVectorTileSourceProvider.test.tsx
+++ b/src/contexts/AzureMapVectorTileSourceProvider.test.tsx
@@ -1,7 +1,7 @@
-import { renderHook } from '@testing-library/react-hooks'
+import { renderHook } from '@testing-library/react'
 import React, { useContext } from 'react'
 import { Map } from 'azure-maps-control'
-import { IAzureVectorTileSourceStatefulProviderProps } from "../types"
+import { IAzureVectorTileSourceStatefulProviderProps } from '../types'
 import { AzureMapsContext } from './AzureMapContext'
 import { AzureMapVectorTileSourceProvider } from './AzureMapVectorTileSourceProvider'
 import { AzureMapDataSourceContext } from '../contexts/AzureMapDataSourceContext'
@@ -32,7 +32,9 @@ const wrapWithVectorTileSourceContext = (props: IAzureVectorTileSourceStatefulPr
         mapRef
       }}
     >
-      <AzureMapVectorTileSourceProvider {...{ ...props }}>{children}</AzureMapVectorTileSourceProvider>
+      <AzureMapVectorTileSourceProvider {...{ ...props }}>
+        {children}
+      </AzureMapVectorTileSourceProvider>
     </AzureMapsContext.Provider>
   )
 }
@@ -58,7 +60,10 @@ describe('AzureMapVectorTileSourceProvider tests', () => {
   it('should add event to data source', () => {
     mapRef.events.add = jest.fn()
     renderHook(() => useContextConsumer(), {
-      wrapper: wrapWithVectorTileSourceContext({ id: 'id', events: { sourceadded: (source) => {} } })
+      wrapper: wrapWithVectorTileSourceContext({
+        id: 'id',
+        events: { sourceadded: (source) => {} }
+      })
     })
     expect(mapRef.events.add).toHaveBeenCalledWith(
       'sourceadded',

--- a/src/hooks/useAzureMapLayer.test.tsx
+++ b/src/hooks/useAzureMapLayer.test.tsx
@@ -1,6 +1,6 @@
 import atlas, { source, layer } from 'azure-maps-control'
 import { ReactNode } from 'react'
-import { renderHook } from '@testing-library/react-hooks'
+import { renderHook } from '@testing-library/react'
 import { useAzureMapLayer } from './useAzureMapLayer'
 import { Map } from 'azure-maps-control'
 import React from 'react'

--- a/src/hooks/useCheckRef.test.tsx
+++ b/src/hooks/useCheckRef.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks'
+import { renderHook } from '@testing-library/react'
 import { useCheckRef, useCheckRefMount } from './useCheckRef'
 
 describe('useCheckRef tests', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { ComponentClass, CSSProperties, ReactElement, StatelessComponent } from 'react'
+import { ComponentClass, CSSProperties, ReactElement, ReactNode, FunctionComponent } from 'react'
 import atlas, {
   AnimationOptions,
   CameraBoundsOptions,
@@ -51,7 +51,7 @@ export type IAzureMap = {
   providedMapId?: string
   containerClassName?: string
   styles?: CSSProperties
-  LoaderComponent?: ComponentClass<any> | StatelessComponent<any>
+  LoaderComponent?: ComponentClass<any> | FunctionComponent<any>
   options?: IAzureMapOptions
   imageSprites?: IAzureMapImageSprite[]
   controls?: IAzureMapControls[]
@@ -129,7 +129,7 @@ export type IAzureMapLayerContextState = {
 }
 
 export type IAzureDataSourceChildren =
-  | IAzureMapFeature
+  | (IAzureMapFeature & ReactNode)
   | ReactElement<IAzureMapFeature>
   | ReactElement<IAzureLayerStatefulProviderProps>
 
@@ -160,9 +160,10 @@ export type IAzureMapEvent = {
 
 export type IAzureDataSourceStatefulProviderProps = {
   id: string
-  children?: | Array<IAzureDataSourceChildren | IAzureDataSourceChildren[] | null>
-  | IAzureDataSourceChildren
-  | null
+  children?:
+    | Array<IAzureDataSourceChildren | IAzureDataSourceChildren[] | null>
+    | IAzureDataSourceChildren
+    | null
   options?: DataSourceOptions
   events?: IAzureMapDataSourceEvent | any
   dataFromUrl?: string
@@ -177,11 +178,12 @@ export type IAzureDataSourceStatefulProviderProps = {
 }
 
 export type IAzureVectorTileSourceStatefulProviderProps = {
-  id: string,
-  children?: | Array<IAzureVectorTileSourceChildren | IAzureVectorTileSourceChildren[] | null>
-  | IAzureVectorTileSourceChildren
-  | null
-  options?: VectorTileSourceOptions,
+  id: string
+  children?:
+    | Array<IAzureVectorTileSourceChildren | IAzureVectorTileSourceChildren[] | null>
+    | IAzureVectorTileSourceChildren
+    | null
+  options?: VectorTileSourceOptions
   events?: IAzureMapVectorTileSourceEvent
   // NOTE: not sure yet why this is needed, haven't seen this used in AzureMapsDataSource, though IAzureGeoJSONDataSourceStatefulProviderProps has it
   index?: number

--- a/yarn.lock
+++ b/yarn.lock
@@ -2100,19 +2100,19 @@
     "@svgr/plugin-svgo" "^5.4.0"
     loader-utils "^2.0.0"
 
-"@testing-library/dom@^7.28.1":
-  version "7.30.1"
-  resolved "https://registry.npmjs.org/@testing-library/dom/-/dom-7.30.1.tgz"
-  integrity sha512-RQUvqqq2lxTCOffhSNxpX/9fCoR+nwuQPmG5uhuuEH5KBAzNf2bK3OzBoWjm5zKM78SLjnGRAKt8hRjQA4E46A==
+"@testing-library/dom@^8.5.0":
+  version "8.16.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.16.0.tgz#d6fc50250aed17b1035ca1bd64655e342db3936a"
+  integrity sha512-uxF4zmnLHHDlmW4l+0WDjcgLVwCvH+OVLpD8Dfp+Bjfz85prwxWGbwXgJdLtkgjD0qfOzkJF9SmA6YZPsMYX4w==
   dependencies:
     "@babel/code-frame" "^7.10.4"
     "@babel/runtime" "^7.12.5"
     "@types/aria-query" "^4.2.0"
-    aria-query "^4.2.2"
+    aria-query "^5.0.0"
     chalk "^4.1.0"
-    dom-accessibility-api "^0.5.4"
+    dom-accessibility-api "^0.5.9"
     lz-string "^1.4.4"
-    pretty-format "^26.6.2"
+    pretty-format "^27.0.2"
 
 "@testing-library/jest-dom@^5.11.4":
   version "5.11.10"
@@ -2128,25 +2128,14 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
-"@testing-library/react-hooks@^5.1.0":
-  version "5.1.0"
-  resolved "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-5.1.0.tgz"
-  integrity sha512-ChRyyA14e0CeVkWGp24v8q/IiWUqH+B8daRx4lGZme4dsudmMNWz+Qo2Q2NzbD2O5rAVXh2hSbS/KTKeqHYhkw==
+"@testing-library/react@^13.3.0":
+  version "13.3.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-13.3.0.tgz#bf298bfbc5589326bbcc8052b211f3bb097a97c5"
+  integrity sha512-DB79aA426+deFgGSjnf5grczDPiL4taK3hFaa+M5q7q20Kcve9eQottOG5kZ74KEr55v0tU2CQormSSDK87zYQ==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@types/react" ">=16.9.0"
-    "@types/react-dom" ">=16.9.0"
-    "@types/react-test-renderer" ">=16.9.0"
-    filter-console "^0.1.1"
-    react-error-boundary "^3.1.0"
-
-"@testing-library/react@^11.1.0":
-  version "11.2.5"
-  resolved "https://registry.npmjs.org/@testing-library/react/-/react-11.2.5.tgz"
-  integrity sha512-yEx7oIa/UWLe2F2dqK0FtMF9sJWNXD+2PPtp39BvE0Kh9MJ9Kl0HrZAgEuhUJR+Lx8Di6Xz+rKwSdEPY2UV8ZQ==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    "@testing-library/dom" "^7.28.1"
+    "@testing-library/dom" "^8.5.0"
+    "@types/react-dom" "^18.0.0"
 
 "@testing-library/user-event@^12.1.10":
   version "12.8.3"
@@ -2325,24 +2314,26 @@
   resolved "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz"
   integrity sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug==
 
-"@types/react-dom@>=16.9.0", "@types/react-dom@^17.0.11":
-  version "17.0.17"
-  resolved "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.17.tgz"
-  integrity sha512-VjnqEmqGnasQKV0CWLevqMTXBYG9GbwuE6x3VetERLh0cq2LTptFE73MrQi2S7GkKXCf2GgwItB/melLnxfnsg==
-  dependencies:
-    "@types/react" "^17"
-
-"@types/react-test-renderer@>=16.9.0":
-  version "17.0.1"
-  resolved "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz"
-  integrity sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==
+"@types/react-dom@^18.0.0", "@types/react-dom@^18.0.6":
+  version "18.0.6"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.6.tgz#36652900024842b74607a17786b6662dd1e103a1"
+  integrity sha512-/5OFZgfIPSwy+YuIBP/FgJnQnsxhZhjjrnxudMddeblOouIodEQ75X14Rr4wGSG/bknL+Omy9iWlLo1u/9GzAA==
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@>=16.9.0", "@types/react@^17", "@types/react@^17.0.39":
+"@types/react@*":
   version "17.0.47"
   resolved "https://registry.npmjs.org/@types/react/-/react-17.0.47.tgz"
   integrity sha512-mk0BL8zBinf2ozNr3qPnlu1oyVTYq+4V7WA76RgxUAtf0Em/Wbid38KN6n4abEkvO4xMTBWmnP1FtQzgkEiJoA==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@^18.0.15":
+  version "18.0.15"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.15.tgz#d355644c26832dc27f3e6cbf0c4f4603fc4ab7fe"
+  integrity sha512-iz3BtLuIYH1uWdsv6wXYdhozhqj20oD4/Hk2DNXIn1kFsmp9x8d9QB6FnPhfkbhd2PgEONt9Q1x/ebkwjfFLow==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -2861,6 +2852,11 @@ ansi-regex@^5.0.0:
   resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
 
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
@@ -2879,6 +2875,11 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
+
+ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
 ansi-to-html@^0.6.4:
   version "0.6.14"
@@ -2922,6 +2923,11 @@ aria-query@^4.2.2:
   dependencies:
     "@babel/runtime" "^7.10.2"
     "@babel/runtime-corejs3" "^7.10.2"
+
+aria-query@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.0.0.tgz#210c21aaf469613ee8c9a62c7f86525e058db52c"
+  integrity sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==
 
 arity-n@^1.0.4:
   version "1.0.4"
@@ -5472,10 +5478,10 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-dom-accessibility-api@^0.5.4:
-  version "0.5.4"
-  resolved "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.4.tgz"
-  integrity sha512-TvrjBckDy2c6v6RLxPv5QXOnU+SmF9nBII5621Ve5fu6Z/BDrENurBEvlC1f44lKEUVqOpK4w9E5Idc5/EgkLQ==
+dom-accessibility-api@^0.5.9:
+  version "0.5.14"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.14.tgz#56082f71b1dc7aac69d83c4285eef39c15d93f56"
+  integrity sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg==
 
 dom-converter@^0.2:
   version "0.2.0"
@@ -6418,11 +6424,6 @@ fill-range@^7.0.1:
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
   dependencies:
     to-regex-range "^5.0.1"
-
-filter-console@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.npmjs.org/filter-console/-/filter-console-0.1.1.tgz"
-  integrity sha512-zrXoV1Uaz52DqPs+qEwNJWJFAWZpYJ47UNmpN9q4j+/EYsz85uV0DC9k8tRND5kYmoVzL0W+Y75q4Rg8sRJCdg==
 
 finalhandler@~1.1.2:
   version "1.1.2"
@@ -11062,6 +11063,15 @@ pretty-format@^26.0.0, pretty-format@^26.6.0, pretty-format@^26.6.2:
     ansi-styles "^4.0.0"
     react-is "^17.0.1"
 
+pretty-format@^27.0.2:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
+  integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
+  dependencies:
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
+
 private@^0.1.6:
   version "0.1.8"
   resolved "https://registry.npmjs.org/private/-/private-0.1.8.tgz"
@@ -11357,21 +11367,13 @@ react-dev-utils@^11.0.1:
     strip-ansi "6.0.0"
     text-table "0.2.0"
 
-react-dom@^17.0.2:
-  version "17.0.2"
-  resolved "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz"
-  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
+react-dom@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
+  integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    scheduler "^0.20.2"
-
-react-error-boundary@^3.1.0:
-  version "3.1.1"
-  resolved "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.1.tgz"
-  integrity sha512-W3xCd9zXnanqrTUeViceufD3mIW8Ut29BUD+S2f0eO2XCOU8b6UrJfY46RDGe5lxCJzfe4j0yvIfh0RbTZhKJw==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
+    scheduler "^0.23.0"
 
 react-error-overlay@^6.0.9:
   version "6.0.9"
@@ -11459,13 +11461,12 @@ react-scripts@4.0.1:
   optionalDependencies:
     fsevents "^2.1.3"
 
-react@^17.0.2:
-  version "17.0.2"
-  resolved "https://registry.npmjs.org/react/-/react-17.0.2.tgz"
-  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
+react@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
+  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 read-pkg-up@^2.0.0:
   version "2.0.0"
@@ -12176,13 +12177,12 @@ saxes@^5.0.1:
   dependencies:
     xmlchars "^2.2.0"
 
-scheduler@^0.20.2:
-  version "0.20.2"
-  resolved "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz"
-  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
+scheduler@^0.23.0:
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.0.tgz#ba8041afc3d30eb206a487b6b384002e4e61fdfe"
+  integrity sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 schema-utils@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
- Add `.prettierrc` for a consistent formatting
- Use conventional config for commitlint since `chore` is missing from the angular config
- Upgrade `devDependencies` to react 18
- Update `peerDependencies` to support react 18
- Delete `@testing-library/react-hooks` since `renderHook` is now included in `@testing-library/react` ([ref](https://github.com/testing-library/react-testing-library/pull/991))
- Fix `AzureMapContext.test.tsx` by wrapping component updates in `act()`  
- Update types.ts for react 18 ([ref](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210))
  -  `StatelessComponent` -> `FunctionComponent`
  - `IAzureMapFeature` -> `(IAzureMapFeature & ReactNode)`