### PR TITLE
fix: datasource context provider will now cleanup when being unmounted

### DIFF
--- a/__mocks__/azure-maps-control.js
+++ b/__mocks__/azure-maps-control.js
@@ -1,9 +1,18 @@
 class DataSource {
+  id
+  options
+
+  constructor(id, options) {
+    this.id = id
+    this.options = options
+  }
+
   add = jest.fn()
   clear = jest.fn()
   remove = jest.fn()
   importDataFromUrl = jest.fn()
-  setOptions = jest.fn()
+  setOptions = jest.fn((options) => (this.options = options))
+  getId = () => this.id
 }
 
 module.exports = {
@@ -12,8 +21,12 @@ module.exports = {
       add: jest.fn()
     },
     events: {
-      add: jest.fn((eventName, callback = () => {}) => {
-        callback()
+      add: jest.fn((_eventName, _targetOrCallback, callback = () => {}) => {
+        if (typeof _targetOrCallback === 'function') {
+          _targetOrCallback()
+        } else {
+          callback()
+        }
       }),
       remove: jest.fn((eventName) => {})
     },
@@ -27,7 +40,9 @@ module.exports = {
     },
     layers: {
       add: jest.fn(),
-      remove: jest.fn()
+      remove: jest.fn(),
+      getLayers: jest.fn(() => []),
+      getLayerById: jest.fn()
     },
     popups: {
       getPopups: jest.fn(() => []),

--- a/__mocks__/azure-maps-control.js
+++ b/__mocks__/azure-maps-control.js
@@ -14,7 +14,8 @@ module.exports = {
     events: {
       add: jest.fn((eventName, callback = () => {}) => {
         callback()
-      })
+      }),
+      remove: jest.fn((eventName) => {})
     },
     imageSprite: {
       add: jest.fn(),
@@ -123,7 +124,7 @@ module.exports = {
     VectorTileSource: jest.fn((id, options) => ({
       getId: jest.fn(() => id),
       getOptions: jest.fn(() => options)
-    })) 
+    }))
   },
   Shape: jest.fn(() => ({
     setCoordinates: jest.fn(),
@@ -132,7 +133,7 @@ module.exports = {
   data: {
     Position: jest.fn((...args) => args),
     BoundingBox: jest.fn((...args) => args),
-    Point: jest.fn(coords => ({ coords, type: 'Point' })),
+    Point: jest.fn((coords) => ({ coords, type: 'Point' })),
     MultiPoint: jest.fn((coords, bbox) => ({ coords, bbox, type: 'MultiPoint' })),
     LineString: jest.fn((coords, bbox) => ({ coords, bbox, type: 'LineString' })),
     MultiLineString: jest.fn((multipleCoordinates, bbox) => ({

--- a/src/components/helpers/mapHelper.ts
+++ b/src/components/helpers/mapHelper.ts
@@ -1,6 +1,9 @@
 import atlas from 'azure-maps-control'
+import { DataSourceType, MapType } from '../../types'
 
-export const generateLinesFromArrayOfPosition = (coordinates: atlas.data.Position[]): atlas.data.LineString => {
+export const generateLinesFromArrayOfPosition = (
+  coordinates: atlas.data.Position[]
+): atlas.data.LineString => {
   const line = new atlas.data.LineString(coordinates)
   return line
 }
@@ -8,4 +11,15 @@ export const generateLinesFromArrayOfPosition = (coordinates: atlas.data.Positio
 export const generatePixelHeading = (origin: atlas.Pixel, destination: atlas.Pixel) => {
   const heading = atlas.Pixel.getHeading(origin, destination)
   return heading
+}
+
+export const getLayersDependingOnDatasource = (mref: MapType, dst: DataSourceType) => {
+  return mref.layers.getLayers().filter((l) => {
+    if ((l as atlas.layer.SymbolLayer).getSource) {
+      const sourceLayer = (l as atlas.layer.SymbolLayer).getSource()
+      const dsId = typeof sourceLayer === 'string' ? sourceLayer : sourceLayer.getId()
+      return dsId === dst.getId()
+    }
+    return false
+  })
 }

--- a/src/contexts/AzureMapContext.test.tsx
+++ b/src/contexts/AzureMapContext.test.tsx
@@ -5,6 +5,7 @@ import { Map } from 'azure-maps-control'
 import { AzureMapsContext, AzureMapsProvider } from '../contexts/AzureMapContext'
 
 const mapRef = new Map('fake', {})
+mapRef.layers.getLayers = jest.fn().mockImplementation(() => [])
 
 const useContextConsumer = () => {
   const mapContext = useContext(AzureMapsContext)

--- a/src/contexts/AzureMapContext.test.tsx
+++ b/src/contexts/AzureMapContext.test.tsx
@@ -5,7 +5,6 @@ import { Map } from 'azure-maps-control'
 import { AzureMapsContext, AzureMapsProvider } from '../contexts/AzureMapContext'
 
 const mapRef = new Map('fake', {})
-mapRef.layers.getLayers = jest.fn().mockImplementation(() => [])
 
 const useContextConsumer = () => {
   const mapContext = useContext(AzureMapsContext)

--- a/src/contexts/AzureMapDataSourceContext.test.tsx
+++ b/src/contexts/AzureMapDataSourceContext.test.tsx
@@ -93,12 +93,29 @@ describe('AzureMapDataSourceProvider tests', () => {
   })
 
   it('should call setOptions and clear method if options was changed', () => {
-    const { result, rerender } = renderHook(() => useContextConsumer(), {
+    const { result } = renderHook(() => useContextConsumer(), {
       wrapper: wrapWithDataSourceContext({ id: 'id', options: { option: 'option' } })
     })
     expect(result.current.dataSourceRef).toBeInstanceOf(atlas.source.DataSource)
     expect(
       (result.current.dataSourceRef as atlas.source.DataSource).setOptions
     ).toHaveBeenLastCalledWith({ option: 'option' })
+  })
+
+  it('should remove data source from the map ref on unmount', () => {
+    mapRef.events.remove = jest.fn()
+    const events = { render: () => {} }
+    const { unmount, result } = renderHook(() => useContextConsumer(), {
+      wrapper: wrapWithDataSourceContext({ id: 'id', options: { option: 'option' }, events })
+    })
+
+    unmount()
+
+    expect(mapRef.sources.remove).toHaveBeenCalledWith(result.current.dataSourceRef)
+    expect(mapRef.events.remove).toHaveBeenCalledWith(
+      'render',
+      result.current.dataSourceRef,
+      events.render
+    )
   })
 })

--- a/src/contexts/AzureMapDataSourceContext.test.tsx
+++ b/src/contexts/AzureMapDataSourceContext.test.tsx
@@ -17,6 +17,8 @@ const mapContextProps = {
   setMapRef: jest.fn()
 }
 const mapRef = new Map('fake', {})
+mapRef.layers.getLayers = jest.fn().mockImplementation(() => [])
+mapRef.layers.getLayerById = jest.fn()
 
 const useContextConsumer = () => {
   const dataSourceContext = useContext(AzureMapDataSourceContext)

--- a/src/contexts/AzureMapDataSourceContext.tsx
+++ b/src/contexts/AzureMapDataSourceContext.tsx
@@ -53,15 +53,20 @@ const AzureMapDataSourceStatefulProvider = ({
         mref.events.remove(eventType as any, dref, events[eventType])
       }
 
-      mref.layers.getLayers().filter(l => {
-        return (l as atlas.layer.SymbolLayer).getSource
-      }).forEach(l => {
-        const source = (l as atlas.layer.SymbolLayer).getSource();
-        const id = (typeof source === 'string') ? source : source.getId();
-        if (id === dref.getId()) {
-          mref.layers.remove(l.getId() ? l.getId() : l);
-        }
-      });
+      const getLayersDependingOnDatasource = (dst: DataSourceType) => {
+        return mref.layers.getLayers().filter((l) => {
+          if ((l as atlas.layer.SymbolLayer).getSource) {
+            const sourceLayer = (l as atlas.layer.SymbolLayer).getSource()
+            const dsId = typeof sourceLayer === 'string' ? sourceLayer : sourceLayer.getId()
+            return dsId === dst.getId()
+          }
+          return false
+        })
+      }
+
+      getLayersDependingOnDatasource(dref).forEach((l) => {
+        mref.layers.remove(l.getId() ? l.getId() : l)
+      })
       mref.sources.remove(dref)
     }
   })

--- a/src/contexts/AzureMapDataSourceContext.tsx
+++ b/src/contexts/AzureMapDataSourceContext.tsx
@@ -9,6 +9,7 @@ import {
 import atlas from 'azure-maps-control'
 import { AzureMapsContext } from './AzureMapContext'
 import { useCheckRef } from '../hooks/useCheckRef'
+import { getLayersDependingOnDatasource } from '../components/helpers/mapHelper'
 
 const AzureMapDataSourceContext = createContext<IAzureMapDataSourceProps>({
   dataSourceRef: null
@@ -53,18 +54,7 @@ const AzureMapDataSourceStatefulProvider = ({
         mref.events.remove(eventType as any, dref, events[eventType])
       }
 
-      const getLayersDependingOnDatasource = (dst: DataSourceType) => {
-        return mref.layers.getLayers().filter((l) => {
-          if ((l as atlas.layer.SymbolLayer).getSource) {
-            const sourceLayer = (l as atlas.layer.SymbolLayer).getSource()
-            const dsId = typeof sourceLayer === 'string' ? sourceLayer : sourceLayer.getId()
-            return dsId === dst.getId()
-          }
-          return false
-        })
-      }
-
-      getLayersDependingOnDatasource(dref).forEach((l) => {
+      getLayersDependingOnDatasource(mref, dref).forEach((l) => {
         mref.layers.remove(l.getId() ? l.getId() : l)
       })
       mref.sources.remove(dref)

--- a/src/contexts/AzureMapDataSourceContext.tsx
+++ b/src/contexts/AzureMapDataSourceContext.tsx
@@ -52,6 +52,16 @@ const AzureMapDataSourceStatefulProvider = ({
       for (const eventType in events || {}) {
         mref.events.remove(eventType as any, dref, events[eventType])
       }
+
+      mref.layers.getLayers().filter(l => {
+        return (l as atlas.layer.SymbolLayer).getSource
+      }).forEach(l => {
+        const source = (l as atlas.layer.SymbolLayer).getSource();
+        const id = (typeof source === 'string') ? source : source.getId();
+        if (id === dref.getId()) {
+          mref.layers.remove(l.getId() ? l.getId() : l);
+        }
+      });
       mref.sources.remove(dref)
     }
   })

--- a/src/contexts/AzureMapDataSourceContext.tsx
+++ b/src/contexts/AzureMapDataSourceContext.tsx
@@ -31,7 +31,9 @@ const AzureMapDataSourceStatefulProvider = ({
   dataFromUrl,
   collection
 }: IAzureDataSourceStatefulProviderProps) => {
-  const [dataSourceRef] = useState<atlas.source.DataSource>(new atlas.source.DataSource(id, options))
+  const [dataSourceRef] = useState<atlas.source.DataSource>(
+    new atlas.source.DataSource(id, options)
+  )
   const { mapRef } = useContext<IAzureMapsContextProps>(AzureMapsContext)
   useCheckRef<MapType, DataSourceType>(mapRef, dataSourceRef, (mref, dref) => {
     for (const eventType in events || {}) {
@@ -45,6 +47,12 @@ const AzureMapDataSourceStatefulProvider = ({
       if (collection) {
         dref.add(collection)
       }
+    }
+    return () => {
+      for (const eventType in events || {}) {
+        mref.events.remove(eventType as any, dref, events[eventType])
+      }
+      mref.sources.remove(dref)
     }
   })
 

--- a/src/contexts/AzureMapVectorTileSourceProvider.test.tsx
+++ b/src/contexts/AzureMapVectorTileSourceProvider.test.tsx
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react'
 import React, { useContext } from 'react'
-import { Map } from 'azure-maps-control'
+import atlas, { layer, Map } from 'azure-maps-control'
 import { IAzureVectorTileSourceStatefulProviderProps } from '../types'
 import { AzureMapsContext } from './AzureMapContext'
 import { AzureMapVectorTileSourceProvider } from './AzureMapVectorTileSourceProvider'
@@ -70,5 +70,42 @@ describe('AzureMapVectorTileSourceProvider tests', () => {
       expect.any(Object),
       expect.any(Function)
     )
+  })
+
+  it('should remove data source from the map ref on unmount', () => {
+    mapRef.events.remove = jest.fn()
+    const events = { sourceadded: () => {} }
+    const { unmount, result } = renderHook(() => useContextConsumer(), {
+      wrapper: wrapWithVectorTileSourceContext({ id: 'id', options: { option: 'option' }, events })
+    })
+
+    unmount()
+
+    expect(mapRef.sources.remove).toHaveBeenCalledWith(result.current.dataSourceRef)
+    expect(mapRef.events.remove).toHaveBeenCalledWith(
+      'sourceadded',
+      result.current.dataSourceRef,
+      events.sourceadded
+    )
+  })
+
+  it('should remove all layers that are using the same datasource from the map ref on unmount', () => {
+    const dsToBeRemoved = new atlas.source.DataSource('ds_to_be_removed')
+    const dsToKeep = new atlas.source.DataSource('ds_to_keep')
+
+    const symbolLayer = new layer.SymbolLayer(dsToBeRemoved, 'layer_to_be_removed')
+    const bubbleLayer = new layer.BubbleLayer(dsToKeep, 'layer_to_keep')
+
+    symbolLayer.getSource = jest.fn(() => dsToBeRemoved)
+
+    mapRef.layers.getLayers = jest.fn(() => [symbolLayer, bubbleLayer])
+
+    const { unmount } = renderHook(() => useContextConsumer(), {
+      wrapper: wrapWithVectorTileSourceContext({ id: dsToBeRemoved.getId() })
+    })
+
+    unmount()
+    expect(mapRef.layers.remove).toHaveBeenCalledTimes(1)
+    expect(mapRef.layers.remove).toHaveBeenNthCalledWith(1, 'layer_to_be_removed')
   })
 })

--- a/src/contexts/AzureMapVectorTileSourceProvider.tsx
+++ b/src/contexts/AzureMapVectorTileSourceProvider.tsx
@@ -1,7 +1,13 @@
 import atlas from 'azure-maps-control'
 import React, { useContext, useState } from 'react'
 import { useCheckRef } from '../hooks/useCheckRef'
-import { DataSourceType, IAzureMapsContextProps, IAzureMapSourceEventType, IAzureVectorTileSourceStatefulProviderProps, MapType } from '../types'
+import {
+  DataSourceType,
+  IAzureMapsContextProps,
+  IAzureMapSourceEventType,
+  IAzureVectorTileSourceStatefulProviderProps,
+  MapType
+} from '../types'
 import { AzureMapDataSourceRawProvider as Provider } from './AzureMapDataSourceContext'
 import { AzureMapsContext } from './AzureMapContext'
 
@@ -15,24 +21,55 @@ const AzureMapVectorTileSourceStatefulProvider = ({
   id,
   children,
   options,
-  events = {},
+  events = {}
 }: IAzureVectorTileSourceStatefulProviderProps) => {
-  const [dataSourceRef] = useState<atlas.source.VectorTileSource>(new atlas.source.VectorTileSource(id, options))
+  const [dataSourceRef] = useState<atlas.source.VectorTileSource>(
+    new atlas.source.VectorTileSource(id, options)
+  )
   const { mapRef } = useContext<IAzureMapsContextProps>(AzureMapsContext)
   useCheckRef<MapType, DataSourceType>(mapRef, dataSourceRef, (mref, dref) => {
     for (const eventType in events) {
-      const handler = events[eventType as IAzureMapSourceEventType] as (e: atlas.source.Source) => void | undefined
-      if(handler) {
+      const handler = events[eventType as IAzureMapSourceEventType] as (
+        e: atlas.source.Source
+      ) => void | undefined
+      if (handler) {
         mref.events.add(eventType as IAzureMapSourceEventType, dref, handler)
       }
     }
     mref.sources.add(dref)
+
+    return () => {
+      for (const eventType in events || {}) {
+        const handler = events[eventType as IAzureMapSourceEventType] as (
+          e: atlas.source.Source
+        ) => void | undefined
+        if (handler) {
+          mref.events.remove(eventType as IAzureMapSourceEventType, dref, handler)
+        }
+      }
+
+      const getLayersDependingOnDatasource = (dst: DataSourceType) => {
+        return mref.layers.getLayers().filter((l) => {
+          if ((l as atlas.layer.SymbolLayer).getSource) {
+            const sourceLayer = (l as atlas.layer.SymbolLayer).getSource()
+            const dsId = typeof sourceLayer === 'string' ? sourceLayer : sourceLayer.getId()
+            return dsId === dst.getId()
+          }
+          return false
+        })
+      }
+
+      getLayersDependingOnDatasource(dref).forEach((l) => {
+        mref.layers.remove(l.getId() ? l.getId() : l)
+      })
+      mref.sources.remove(dref)
+    }
   })
 
   return (
     <Provider
       value={{
-        dataSourceRef,
+        dataSourceRef
       }}
     >
       {mapRef && children}

--- a/src/contexts/AzureMapVectorTileSourceProvider.tsx
+++ b/src/contexts/AzureMapVectorTileSourceProvider.tsx
@@ -10,6 +10,7 @@ import {
 } from '../types'
 import { AzureMapDataSourceRawProvider as Provider } from './AzureMapDataSourceContext'
 import { AzureMapsContext } from './AzureMapContext'
+import { getLayersDependingOnDatasource } from '../components/helpers/mapHelper'
 
 /**
  * @param id datasource identifier
@@ -48,18 +49,7 @@ const AzureMapVectorTileSourceStatefulProvider = ({
         }
       }
 
-      const getLayersDependingOnDatasource = (dst: DataSourceType) => {
-        return mref.layers.getLayers().filter((l) => {
-          if ((l as atlas.layer.SymbolLayer).getSource) {
-            const sourceLayer = (l as atlas.layer.SymbolLayer).getSource()
-            const dsId = typeof sourceLayer === 'string' ? sourceLayer : sourceLayer.getId()
-            return dsId === dst.getId()
-          }
-          return false
-        })
-      }
-
-      getLayersDependingOnDatasource(dref).forEach((l) => {
+      getLayersDependingOnDatasource(mref, dref).forEach((l) => {
         mref.layers.remove(l.getId() ? l.getId() : l)
       })
       mref.sources.remove(dref)

--- a/src/hooks/useAzureMapLayer.test.tsx
+++ b/src/hooks/useAzureMapLayer.test.tsx
@@ -1,4 +1,4 @@
-import atlas, { source, layer } from 'azure-maps-control'
+import { source, layer } from 'azure-maps-control'
 import { ReactNode } from 'react'
 import { renderHook } from '@testing-library/react'
 import { useAzureMapLayer } from './useAzureMapLayer'
@@ -6,7 +6,7 @@ import { Map } from 'azure-maps-control'
 import React from 'react'
 import { AzureMapsContext } from '../contexts/AzureMapContext'
 import { AzureMapDataSourceContext } from '../contexts/AzureMapDataSourceContext'
-import { IAzureLayerStatefulProviderProps, LayerType } from '../types'
+import { IAzureLayerStatefulProviderProps } from '../types'
 
 const mapContextProps = {
   mapRef: null,
@@ -16,6 +16,7 @@ const mapContextProps = {
   setMapRef: jest.fn()
 }
 const mapRef = new Map('fake', {})
+mapRef.layers.getLayerById = jest.fn().mockImplementation(() => null)
 
 const wrapWithAzureMapContext = ({ children }: { children?: ReactNode | null }) => {
   const datasourceRef = {} as source.DataSource
@@ -109,6 +110,8 @@ describe('useAzureMapLayer tests', () => {
   })
 
   it('shouldRemove layer from map on unmoun', () => {
+    const symbolLayer = {} as layer.SymbolLayer
+    mapRef.layers.getLayerById = jest.fn().mockImplementation(() => symbolLayer)
     mapRef.layers.remove = jest.fn()
     const { unmount } = renderHook(
       () =>

--- a/src/hooks/useAzureMapLayer.tsx
+++ b/src/hooks/useAzureMapLayer.tsx
@@ -70,7 +70,9 @@ export const useAzureMapLayer = ({
     mref.layers.add(lref)
     return () => {
       try {
-        mref.layers.remove(lref.getId() ? lref.getId() : lref)
+        if (mref.layers.getLayerById(lref.getId())) {
+          mref.layers.remove(lref.getId() ? lref.getId() : lref)
+        }
       } catch (e) {
         console.error('Error on remove layer', e)
       }


### PR DESCRIPTION
`<AzureMapDataSourceProvider />` does not work well with React.StrictMode

Strict mode will render, unmount and rerender again to find common issues see:  https://reactjs.org/docs/strict-mode.html
When Strict mode is enabled, it will throw the following error: `Uncaught Error: 'datasource-id' is already added to the map` (map will not render anymore)

This PR fixes this issue by doing a cleanup when `<AzureMapDataSourceProvider />` is being unmounted. 

note: This PR does not fix any other cleanup issues in other components, so there could be more!