### PR TITLE
fix: using dist version of mapbox gl css

### DIFF
--- a/src/components/AzureMap/AzureMap.tsx
+++ b/src/components/AzureMap/AzureMap.tsx
@@ -27,7 +27,7 @@ const AzureMap = memo(
     styleOptions,
     serviceOptions
   }: IAzureMap) => {
-    const { setMapRef, removeMapRef, mapRef, setMapReady, isMapReady} = useContext<
+    const { setMapRef, removeMapRef, mapRef, setMapReady, isMapReady } = useContext<
       IAzureMapsContextProps
     >(AzureMapsContext)
     const [mapId] = useState(providedMapId || Guid.create().toString())

--- a/src/components/AzureMap/AzureMap.tsx
+++ b/src/components/AzureMap/AzureMap.tsx
@@ -27,13 +27,9 @@ const AzureMap = memo(
     styleOptions,
     serviceOptions
   }: IAzureMap) => {
-    const {
-      setMapRef,
-      removeMapRef,
-      mapRef,
-      setMapReady,
-      isMapReady
-    } = useContext<IAzureMapsContextProps>(AzureMapsContext)
+    const { setMapRef, removeMapRef, mapRef, setMapReady, isMapReady} = useContext<
+      IAzureMapsContextProps
+    >(AzureMapsContext)
     const [mapId] = useState(providedMapId || Guid.create().toString())
     useEffect(() => {
       if (mapRef) {
@@ -65,7 +61,7 @@ const AzureMap = memo(
       }
     }, [serviceOptions])
 
-    useCheckRef<MapType, MapType>(mapRef, mapRef, (mref) => {
+    useCheckRef<MapType, MapType>(mapRef, mapRef, mref => {
       mref.events.add('ready', () => {
         if (imageSprites) {
           createImageSprites(mref, imageSprites)

--- a/src/components/AzureMap/AzureMap.tsx
+++ b/src/components/AzureMap/AzureMap.tsx
@@ -4,7 +4,7 @@ import { IAzureMap, IAzureMapsContextProps, MapType } from '../../types'
 import { AzureMapsContext } from '../../contexts/AzureMapContext'
 import { Guid } from 'guid-typescript'
 import 'azure-maps-control/dist/atlas.min.css'
-import 'mapbox-gl/src/css/mapbox-gl.css'
+import 'mapbox-gl/dist/mapbox-gl.css'
 import { useCheckRef } from '../../hooks/useCheckRef'
 import { createImageSprites } from './useCreateSprites'
 import { createMapControls, createMapCustomControls } from './useCreateMapControls'
@@ -27,9 +27,13 @@ const AzureMap = memo(
     styleOptions,
     serviceOptions
   }: IAzureMap) => {
-    const { setMapRef, removeMapRef, mapRef, setMapReady, isMapReady } = useContext<
-      IAzureMapsContextProps
-    >(AzureMapsContext)
+    const {
+      setMapRef,
+      removeMapRef,
+      mapRef,
+      setMapReady,
+      isMapReady
+    } = useContext<IAzureMapsContextProps>(AzureMapsContext)
     const [mapId] = useState(providedMapId || Guid.create().toString())
     useEffect(() => {
       if (mapRef) {
@@ -61,7 +65,7 @@ const AzureMap = memo(
       }
     }, [serviceOptions])
 
-    useCheckRef<MapType, MapType>(mapRef, mapRef, mref => {
+    useCheckRef<MapType, MapType>(mapRef, mapRef, (mref) => {
       mref.events.add('ready', () => {
         if (imageSprites) {
           createImageSprites(mref, imageSprites)


### PR DESCRIPTION
Hi,

I  noticed react-azure-maps was importing the src version of `Mapbox gl`.
This can be inconvenient because now you have to setup a postcss configuration in your project if you want `Mapbox gl` to work properly

Tailwind with a postcss configuration even fails because of a limitation (nested selectors within a @media query fails, which is used in the src version of `Mapbox gl`)

this PR will make it much simpler by including the dist version of `Mapbox gl`