### PR TITLE
exporting azure maps subscription enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,7 @@ The library implements a lot of ready to use components like `AzureMapFeature, A
 
 ```javascript
 import React from 'react'
-import {AzureMap, AzureMapsProvider, IAzureMapOptions} from 'react-azure-maps'
-import {AuthenticationType} from 'azure-maps-control'
+import {AzureMap, AzureMapsProvider, IAzureMapOptions, AuthenticationType} from 'react-azure-maps'
 
 const option: IAzureMapOptions = {
     authOptions: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,7 +33,8 @@ import atlas, {
   Control,
   BubbleLayerOptions,
   LayerOptions,
-  VectorTileSourceOptions
+  VectorTileSourceOptions,
+  AuthenticationType as AzureMapsAuthenticationType
 } from 'azure-maps-control'
 
 export type IAzureMapOptions = ServiceOptions &
@@ -161,28 +162,28 @@ export type IAzureMapEvent = {
 export type IAzureDataSourceStatefulProviderProps = {
   id: string
   children?:
-    | Array<IAzureDataSourceChildren | IAzureDataSourceChildren[] | null>
-    | IAzureDataSourceChildren
-    | null
+  | Array<IAzureDataSourceChildren | IAzureDataSourceChildren[] | null>
+  | IAzureDataSourceChildren
+  | null
   options?: DataSourceOptions
   events?: IAzureMapDataSourceEvent | any
   dataFromUrl?: string
   collection?:
-    | atlas.data.FeatureCollection
-    | atlas.data.Feature<atlas.data.Geometry, any>
-    | atlas.data.Geometry
-    | atlas.data.GeometryCollection
-    | Shape
-    | Array<atlas.data.Feature<atlas.data.Geometry, any> | atlas.data.Geometry | Shape>
+  | atlas.data.FeatureCollection
+  | atlas.data.Feature<atlas.data.Geometry, any>
+  | atlas.data.Geometry
+  | atlas.data.GeometryCollection
+  | Shape
+  | Array<atlas.data.Feature<atlas.data.Geometry, any> | atlas.data.Geometry | Shape>
   index?: number
 }
 
 export type IAzureVectorTileSourceStatefulProviderProps = {
   id: string
   children?:
-    | Array<IAzureVectorTileSourceChildren | IAzureVectorTileSourceChildren[] | null>
-    | IAzureVectorTileSourceChildren
-    | null
+  | Array<IAzureVectorTileSourceChildren | IAzureVectorTileSourceChildren[] | null>
+  | IAzureVectorTileSourceChildren
+  | null
   options?: VectorTileSourceOptions
   events?: IAzureMapVectorTileSourceEvent
   // NOTE: not sure yet why this is needed, haven't seen this used in AzureMapsDataSource, though IAzureGeoJSONDataSourceStatefulProviderProps has it
@@ -202,16 +203,16 @@ export type IAzureMapLifecycleEvent = {
 export type IAzureLayerStatefulProviderProps = {
   id?: string
   options?:
-    | (SymbolLayerOptions &
-        HeatMapLayerOptions &
-        ImageLayerOptions &
-        LineLayerOptions &
-        PolygonExtrusionLayerOptions &
-        PolygonLayerOptions &
-        TileLayerOptions &
-        BubbleLayerOptions &
-        LayerOptions)
-    | Options
+  | (SymbolLayerOptions &
+    HeatMapLayerOptions &
+    ImageLayerOptions &
+    LineLayerOptions &
+    PolygonExtrusionLayerOptions &
+    PolygonLayerOptions &
+    TileLayerOptions &
+    BubbleLayerOptions &
+    LayerOptions)
+  | Options
   type: IAzureMapLayerType
   events?: IAzureMapLayerEvent | any
   onCreateCustomLayer?: (dataSourceRef: DataSourceType, mapRef: MapType | null) => atlas.layer.Layer
@@ -316,10 +317,10 @@ export type IAzureMapFeature = {
   properties?: Options
   // Shape functions:
   setCoords?:
-    | atlas.data.Position
-    | atlas.data.Position[]
-    | atlas.data.Position[][]
-    | atlas.data.Position[][][]
+  | atlas.data.Position
+  | atlas.data.Position[]
+  | atlas.data.Position[][]
+  | atlas.data.Position[][][]
   setProperties?: Options
 }
 
@@ -340,3 +341,4 @@ export type AzureDataLineString = atlas.data.LineString
 export type AzureDataPosition = atlas.data.Position
 export type ControlOptions = atlas.ControlOptions
 export type AzureSetCameraOptions = ((CameraOptions | CameraBoundsOptions) & AnimationOptions) | any
+export type AuthenticationType = AzureMapsAuthenticationType


### PR DESCRIPTION
fixing issue [120](https://github.com/Azure/react-azure-maps/issues/120)

problem with the import of subscription type from the parent node_mdules/azure-maps-control that returns this error:
![image](https://user-images.githubusercontent.com/56331958/228638340-31e96525-3ed3-4460-93e5-751df9721ac9.png)

fixed that exporting it from inside the react-azure-maps

