### PR TITLE
Update package.json to use common js properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
     "maps",
     "react-azure-maps"
   ],
-  "module": "dist/react-azure-maps.es5.js",
+  "main": "dist/react-azure-maps.es5.js",
   "types": "dist/types/react-azure-maps.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/react-azure-maps.es5.js",
+      "require": "./dist/react-azure-maps.es5.js",
       "types": "./dist/types/react-azure-maps.d.ts"
     }
   },


### PR DESCRIPTION
`module` and `export/import` are meant to reference es module files. Our bundler (Parcel) throws an error when parses react-azure-maps.es5.js an doesn't find any exports.

Node docs on the "exports" property: https://nodejs.org/api/packages.html#conditional-exports. "main": https://nodejs.org/api/packages.html#main. "module" was a proposal that wasn't adopted and isn't officially supported. Some bundlers still use it.