### PR TITLE
fix: slow intersections on IAzureLayerStatefulProviderProps type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -199,19 +199,27 @@ export type IAzureMapLifecycleEvent = {
   [property in IAzureMapLayerLifecycleEvents]: (e: atlas.layer.Layer) => void
 }
 
+export interface IAzureLayerStatefulProviderOptions
+  extends SymbolLayerOptions,
+    HeatMapLayerOptions,
+    ImageLayerOptions,
+    LineLayerOptions,
+    PolygonExtrusionLayerOptions,
+    PolygonLayerOptions,
+    TileLayerOptions,
+    BubbleLayerOptions,
+    LayerOptions {
+  opacity: HeatMapLayerOptions['opacity'] &
+    ImageLayerOptions['opacity'] &
+    TileLayerOptions['opacity']
+  color: HeatMapLayerOptions['color'] & BubbleLayerOptions['color']
+  radius: HeatMapLayerOptions['radius'] & BubbleLayerOptions['radius']
+  fillOpacity: PolygonExtrusionLayerOptions['fillOpacity'] & PolygonLayerOptions['fillOpacity']
+}
+
 export type IAzureLayerStatefulProviderProps = {
   id?: string
-  options?:
-    | (SymbolLayerOptions &
-        HeatMapLayerOptions &
-        ImageLayerOptions &
-        LineLayerOptions &
-        PolygonExtrusionLayerOptions &
-        PolygonLayerOptions &
-        TileLayerOptions &
-        BubbleLayerOptions &
-        LayerOptions)
-    | Options
+  options?: IAzureLayerStatefulProviderOptions | Options
   type: IAzureMapLayerType
   events?: IAzureMapLayerEvent | any
   onCreateCustomLayer?: (dataSourceRef: DataSourceType, mapRef: MapType | null) => atlas.layer.Layer


### PR DESCRIPTION
I'm part of the Kusto team (Azure Data Explorer) and we stumbled upon a recent issue where the type checker would heavily slow down after a change a member on our team did to tighten up types by referencing `IAzureLayerStatefulProviderProps` in our code.

This caused type checking (`npm run tsc`) to slow down 10-20x the normal time. Usually for our large project it would take 30s to type check but after the introduction of `IAzureLayerStatefulProviderProps` some devs saw a slowdown to 90s and without caching upwards of 5mins-10mins. We found that by removing any reference to `IAzureLayerStatefulProviderProps` and deleting its import then TypeScript would resume back to normal performance levels. 

I found that if we replace the `intersections` (`&`) with `interface` + `extends` then the issue is fixed and TypeScript isn't affected by the slowdown. The assumption here is that TS takes a lot longer to squash all the intersected types down to a single type because each intersecting type has complex shapes on its own defined properties. At least with an `interface` TS does some extra perf tricks and is why they [recommend interfaces over intersections on their performance wiki](https://github.com/microsoft/TypeScript/wiki/Performance#preferring-interfaces-over-intersections)

[You can try out a repro of the issue here in this Codesandbox](https://codesandbox.io/p/devbox/v7vn4d)

In a terminal, run `npm run typecheck` to get the before stats and then manually edit the `types.d.ts` file to include the new changes and run again to see the after stats. Here's a screenshot of the stats I saw. A rough 3x increase in type checking speed which matches our experience.

![image](https://github.com/user-attachments/assets/c2ed5c54-200a-4922-b92b-7e88489240ef)


